### PR TITLE
Compatibility with Latvian ASiC-E documents

### DIFF
--- a/src/SignatureTS.cpp
+++ b/src/SignatureTS.cpp
@@ -156,11 +156,8 @@ void SignatureTS::validate() const
         time_t producedAtT = mktime(&producedAt);
         tm time = ASN1TimeToTM(tsa.time());
         time_t timeT = mktime(&time);
-        if(producedAtT < timeT)
-            EXCEPTION_ADD(exception, "TimeStamp is after OCSP response");
-        else if(producedAtT - timeT > 24 * 60 * 60) // 24h
-            EXCEPTION_ADD(exception, "TimeStamp time and OCSP producedAt are over 24h");
-        else if(producedAtT - timeT > 15 * 60 && !Exception::hasWarningIgnore(Exception::ProducedATLateWarning)) // 15m
+        if((producedAtT - timeT > 15 * 60 || timeT - producedAtT > 15 * 60) &&
+            !Exception::hasWarningIgnore(Exception::ProducedATLateWarning))
         {
             Exception e(EXCEPTION_PARAMS("TimeStamp time and OCSP producedAt are over 15m"));
             e.setCode(Exception::ProducedATLateWarning);


### PR DESCRIPTION
removed "TimeStamp have to be after OCSP response" condition on validation
removed "TimeStamp time and OCSP producedAt have to be within 24h" condition on validation
(security risks raised as the Estonian eID certificates' validity can be suspended temporarily and activated later additional analysis recomended)

SKEID-93

Signed-off-by: Raul Metsma raul@metsma.ee

Recreated open-eid/libdigidocpp#10
