### PR TITLE
Compatibility with Lithuanian ADoc 1.0 documents

### DIFF
--- a/src/ASiC_E.h
+++ b/src/ASiC_E.h
@@ -48,7 +48,6 @@ namespace digidoc
           static const std::string MANIFEST_NAMESPACE;
 
           void save(const std::string &path = "") override;
-          std::string mediaType() const override;
 
           void addAdESSignature(std::istream &sigdata) override;
           Signature* prepareSignature(Signer *signer) override;

--- a/src/ASiC_S.cpp
+++ b/src/ASiC_S.cpp
@@ -36,21 +36,20 @@ using namespace std;
 /**
  * Initialize ASiCS container.
  */
-ASiC_S::ASiC_S()
+ASiC_S::ASiC_S(): ASiContainer(MIMETYPE_ASIC_S)
 {
 }
 
 /**
  * Opens ASiC-S container from a file
  */
-
-ASiC_S::ASiC_S(const string &path)
+ASiC_S::ASiC_S(const string &path): ASiContainer(MIMETYPE_ASIC_S)
 {
-    auto z = load(path, false);
+    auto z = load(path, false, {MIMETYPE_ASIC_S});
     loadContainer(*z.get());
 }
 
-void ASiC_S::save(const string &path)
+void ASiC_S::save(const string &)
 {
     THROW("Not implemented.");
 }
@@ -71,20 +70,12 @@ void ASiC_S::addDataFile(istream *is, const string &fileName, const string &medi
     ASiContainer::addDataFile(is, fileName, mediaType);
 }
 
-Container* ASiC_S::createInternal(const string &path)
+Container* ASiC_S::createInternal(const string &)
 {
     return nullptr;
 }
 
-/**
- * @return returns ASiC-S container mimetype.
- */
-string ASiC_S::mediaType() const
-{
-    return ASiContainer::MIMETYPE_ASIC_S;
-}
-
-void ASiC_S::addAdESSignature(istream &sigdata)
+void ASiC_S::addAdESSignature(istream &)
 {
     THROW("Not implemented.");
 }
@@ -146,12 +137,12 @@ void ASiC_S::loadContainer(const ZipSerialize &z)
     extractTimestamp(z);
 }
 
-Signature* ASiC_S::prepareSignature(Signer *signer)
+Signature* ASiC_S::prepareSignature(Signer *)
 {
     THROW("Not implemented.");
 }
 
-Signature *ASiC_S::sign(Signer* signer)
+Signature *ASiC_S::sign(Signer *)
 {
     THROW("Not implemented.");
 }

--- a/src/ASiC_S.h
+++ b/src/ASiC_S.h
@@ -35,7 +35,6 @@ namespace digidoc
 
     public:
         void save(const std::string &path = "") override;
-        std::string mediaType() const override;
 
         void addDataFile(const std::string &path, const std::string &mediaType) override;
         void addDataFile(std::istream *is, const std::string &fileName, const std::string &mediaType) override;

--- a/src/ASiContainer.h
+++ b/src/ASiContainer.h
@@ -24,6 +24,7 @@
 #include "util/ZipSerialize.h"
 
 #include <memory>
+#include <set>
 
 namespace digidoc
 {
@@ -54,8 +55,10 @@ namespace digidoc
 
           static const std::string MIMETYPE_ASIC_E;
           static const std::string MIMETYPE_ASIC_S;
+          static const std::string MIMETYPE_ADOC;
 
           virtual ~ASiContainer();
+          std::string mediaType() const override;
 
           void addDataFile(const std::string &path, const std::string &mediaType) override;
           void addDataFile(std::istream *is, const std::string &fileName, const std::string &mediaType) override;
@@ -79,11 +82,11 @@ namespace digidoc
           std::vector<Signature*> signatures() const override;
 
       protected:
-          ASiContainer();
+          ASiContainer(const std::string &mimetype);
 
           void addSignature(Signature *signature);
           std::iostream* dataStream(const std::string &path, const ZipSerialize &z) const;
-          std::unique_ptr<ZipSerialize> load(const std::string &path, bool requireMimetype);
+          std::unique_ptr<ZipSerialize> load(const std::string &path, bool requireMimetype, const std::set<std::string> &supported);
           void deleteSignature(Signature* s);
 
           void zpath(const std::string &file);


### PR DESCRIPTION
- Handle ADoc 1.0 mimetype
- ODF does not specify that mimetype should be first in manifest
- Ignore directory entries in manifest

SKEID-63

Signed-off-by: Raul Metsma raul@metsma.ee
