### PR TITLE
Compatibility with Lithuanian ADoc 1.0 documents

### DIFF
--- a/etc/schema/XAdES01903v132-201601.xsd
+++ b/etc/schema/XAdES01903v132-201601.xsd
@@ -374,7 +374,7 @@ EncapsulatedPKIDataType and containers for time-stamp tokens -->
 	</xsd:complexType>
 	<xsd:complexType name="ClaimedRolesListType">
 		<xsd:sequence>
-			<xsd:element name="ClaimedRole" type="xsd:string" maxOccurs="unbounded"/>
+			<xsd:element name="ClaimedRole" type="AnyType" maxOccurs="unbounded"/>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="CertifiedRolesListType">

--- a/libdigidocpp.dox
+++ b/libdigidocpp.dox
@@ -508,14 +508,6 @@ schemaLocation="xmldsig-core-schema.xsd"/> <!-- originally "http://www.w3.org/TR
     </xsd:sequence>
   </xsd:complexType>
 \endcode
-4) The data type of signer’s role has been changed to string due to implementation issues (otherwise the source code generated from the schema would later have to be altered).
-\code{.xml}
-<xsd:complexType name="ClaimedRolesListType">
-  <xsd:sequence>
-    <xsd:element name="ClaimedRole" type="xsd:string" maxOccurs="unbounded"/> <!-- originally type="AnyType" -->
-  </xsd:sequence>
-</xsd:complexType>
-\endcode
 
 <b>Schema XAdES01903v141-201601.xsd</b>
 

--- a/src/SignatureBES.cpp
+++ b/src/SignatureBES.cpp
@@ -1123,8 +1123,8 @@ vector<string> SignatureBES::signerRoles() const
     if ( !claimedRoleOpt.present() )
         return roles;
 
-    const ClaimedRolesListType::ClaimedRoleSequence& claimedRolesSequence = claimedRoleOpt->claimedRole();
-    roles.insert( roles.end(), claimedRolesSequence.begin(), claimedRolesSequence.end() );
+    for(const xades::AnyType &type: claimedRoleOpt->claimedRole())
+        roles.push_back(type.text());
     return roles;
 }
 

--- a/src/xml/AnyType.h
+++ b/src/xml/AnyType.h
@@ -42,17 +42,21 @@ public:
 #endif
 
     AnyType();
+    AnyType(const std::string &text);
     AnyType(const xercesc::DOMElement& e, xml_schema::Flags f = 0, xml_schema::Container* c = 0);
     AnyType(const AnyType& x, xml_schema::Flags f = 0, xml_schema::Container* c = 0);
     virtual ~AnyType();
 
     virtual AnyType* _clone(xml_schema::Flags f = 0, xml_schema::Container* c = 0) const;
 
+    std::string text() const;
+
 protected:
     SPURIOptional SPURI_;
 #ifdef SPUSERNOTICE
     SPUserNoticeOptional SPUserNotice_;
 #endif
+    std::string text_;
 };
 
 void operator<< (xercesc::DOMElement&, const AnyType&);


### PR DESCRIPTION
- Handle ClaimedRole as AnyType
- Reverts back to standard schema and resolve string handling custom AnyType c++ class
  Only affects schema validation (bdoc is still created with string only)

SKEID-73

Signed-off-by: Raul Metsma raul@metsma.ee