### PR TITLE
Doc updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install: case ${TARGET} in
     ./prepare_osx_build_environment.sh all ${TARGET} ${HOST};
     ;;
   *linux*)
-    sudo apt-get update -qq && sudo apt-get install -y libxml-security-c-dev dh-make devscripts dpkg-dev cdbs;
+    sudo apt-get update -qq && sudo apt-get install -y libxml-security-c-dev dh-make devscripts dpkg-dev cdbs doxygen;
     wget http://www.codesynthesis.com/download/xsd/4.0/linux-gnu/x86_64/xsd_4.0.0-1_amd64.deb && sudo dpkg -i xsd_4.0.0-1_amd64.deb;
     ;;
   esac

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ set_ex( TSL_CERT4 "$ENV{TSL_CERT4}" "${CMAKE_SOURCE_DIR}/etc/tl-mp4.crt" CACHE F
 set_ex( TSA_URL "$ENV{TSA_URL}" "http://tsa.sk.ee" CACHE STRING "Default TSA url" )
 set_ex( PDF_URL "$ENV{PDF_URL}" "" CACHE STRING "Default PDF validation url" )
 set( LIBDIGIDOC_LINKED true CACHE BOOL "Link with libdigidoc" )
-set( INSTALL_DOC false CACHE BOOL "Install documentation" )
 set( BUILD_TOOLS true CACHE BOOL "Build digidoc-tool" )
 set( BUILD_TYPE "SHARED" CACHE STRING "Build library as SHARED/STATIC" )
 set( SIGNCERT "" CACHE STRING "Common name of certificate to used sign binaries, empty skip signing" )
@@ -41,16 +40,14 @@ find_package(ZLIB REQUIRED)
 find_package(MiniZip QUIET)
 find_package(SWIG)
 
-if( INSTALL_DOC )
-    if( DOXYGEN_FOUND )
-        configure_file( ${CMAKE_SOURCE_DIR}/etc/Doxyfile.in Doxyfile @ONLY )
-        add_custom_target( docs ALL
-            ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-            COMMENT "Generating API documentation with Doxygen" VERBATIM
-        )
-        install( DIRECTORY ${CMAKE_BINARY_DIR}/doc/ DESTINATION ${CMAKE_INSTALL_DOCDIR} )
-    endif()
+if( DOXYGEN_FOUND )
+    configure_file( ${CMAKE_SOURCE_DIR}/etc/Doxyfile.in Doxyfile @ONLY )
+    add_custom_target( docs ALL
+        ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMENT "Generating API documentation with Doxygen" VERBATIM
+    )
+    install( DIRECTORY ${CMAKE_BINARY_DIR}/doc/ DESTINATION ${CMAKE_INSTALL_DOCDIR} )
     install( DIRECTORY doc/ DESTINATION ${CMAKE_INSTALL_DOCDIR} )
 endif()
 

--- a/README.md
+++ b/README.md
@@ -75,15 +75,10 @@
 
 1. Install dependencies and necessary tools from
 	* [Visual Studio Express 2013 for Windows Desktop](http://www.visualstudio.com/en-us/products/visual-studio-express-vs.aspx)
-	* [Perl] (https://www.perl.org/get.html)
-	* [7-zip] (http://www.7-zip.org)
+	* [Perl](https://www.perl.org/get.html)
+	* [7-zip](http://www.7-zip.org)
 	* [http://www.cmake.org](http://www.cmake.org)
-	* [Xerces-c](http://mirror.cogentco.com/pub/apache//xerces/c/3/sources/xerces-c-3.1.1.zip)
-	* [Xerces-c MSVC2012 Project files](https://issues.apache.org/jira/secure/attachment/12548623/xerces_vc11proj.zip)
-	* [XML-Security-C](http://www.apache.org/dyn/closer.cgi?path=/santuario/c-library/xml-security-c-1.7.2.tar.gz)
-	* [OpenSSL Win32 binaries](https://slproweb.com/products/Win32OpenSSL.html) or [OpenSSL source](https://www.openssl.org/source/)
-	* [ZLib source](http://zlib.net/zlib128.zip)
-	* [swigwin-3.0.5.zip](http://swig.org/download.html) - Optional, for C# bindings
+	* [swigwin-3.0.10.zip](http://swig.org/download.html) - Optional, for C# bindings
 
 2. Fetch the source
 
@@ -102,10 +97,10 @@
 
    Optional CMake parameters:
 
-       -DSWIG_EXECUTABLE=C:/swigwin-3.0.5/swig.exe
+       -DSWIG_EXECUTABLE=C:/swigwin-3.0.10/swig.exe
 
    After running the cmake build, digidoc_csharp.dll along with the C# source files will be created, more info at
-   [README.md](https://github.com/open-eid/libdigidocpp/blob/master/examples/DigiDocCSharp/README.md).
+   [examples/DigiDocCSharp/README.md](examples/DigiDocCSharp/README.md).
 
 
 5. Build
@@ -115,6 +110,12 @@
 6. Execute
 
         src/digidoc-tool.exe
+
+### iOS Experimental
+[examples/libdigidocpp-ios/README.md](examples/libdigidocpp-ios/README.md)
+
+### Android Experimental
+[examples/libdigidocpp-android/README.md](examples/libdigidocpp-android/README.md)
 
 ## Support
 Official builds are provided through official distribution point [installer.id.ee](https://installer.id.ee). If you want support, you need to be using official builds. Contact for assistance by email [abi@id.ee](mailto:abi@id.ee) or [www.id.ee](http://www.id.ee).

--- a/build.ps1
+++ b/build.ps1
@@ -25,7 +25,7 @@ if($swig) {
   $candleext += "-dswig=$swig"
 }
 if($doxygen) {
-  $cmakeext += "-DINSTALL_DOC=YES", "-DDOXYGEN_EXECUTABLE=$doxygen"
+  $cmakeext += "-DDOXYGEN_EXECUTABLE=$doxygen"
   $candleext += "-ddocLocation=x86/share/doc/libdigidocpp", "DocFilesFragment.wxs"
   $lightext += "DocFilesFragment.wixobj"
 }

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,8 @@ Build-Depends:
  cmake,
  libxml-security-c-dev,
  xsdcxx (>= 4.0) | xsd (>= 4.0),
- vim-common
+ vim-common,
+ doxygen
 Standards-Version: 3.9.5
 Homepage: https://github.com/open-eid/libdigidocpp
 

--- a/debian/rules
+++ b/debian/rules
@@ -4,5 +4,4 @@ include /usr/share/cdbs/1/class/cmake.mk
 DEB_CMAKE_EXTRA_FLAGS = \
 	-DCMAKE_INSTALL_SYSCONFDIR="/etc" \
 	-DCMAKE_INSTALL_LIBDIR="lib/$(DEB_HOST_MULTIARCH)" \
-	-DINSTALL_DOC=YES \
 	-DSWIG_EXECUTABLE=""

--- a/etc/Doxyfile.in
+++ b/etc/Doxyfile.in
@@ -781,7 +781,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = @CMAKE_SOURCE_DIR@/src
+INPUT                  = @CMAKE_SOURCE_DIR@/src @CMAKE_SOURCE_DIR@/libdigidocpp.dox
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/libdigidocpp.dox
+++ b/libdigidocpp.dox
@@ -782,7 +782,7 @@ You change the default behaviour in the configuration file with the following pa
 </table>
 
 \subsection sample-conf Sample configuration file
-\code{.html}
+\code{.xml}
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 xsi:noNamespaceSchemaLocation="schema/conf.xsd">


### PR DESCRIPTION
- move index.dox to parent folder and rename to libdigidocpp.dox
- remove obsolete INSTALL_DOC cmake parameter, installation can be disabled with cmake parameter -DDOXYGEN_EXECUTABLE=""
- remove download references form build instructions, they are downloaded with prepare_win_build_environment.ps1 script

Signed-off-by: Raul Metsma <raul@metsma.ee>