### PR TITLE
IB-3793 double click on ZIP-bomb BDOC should not crash

### DIFF
--- a/src/BDoc.cpp
+++ b/src/BDoc.cpp
@@ -490,6 +490,10 @@ void BDoc::parseManifestAndLoadFiles(const ZipSerialize &z, const vector<string>
     {
         THROW("Failed to parse manifest XML: %s (xsd path: %s)", e.what(), Conf::instance()->xsdPath().c_str());
     }
+    catch (...)
+    {
+        THROW("Failed to parse manifest XML: %s", Conf::instance()->xsdPath().c_str());
+    }
 }
 
 Signature* BDoc::prepareSignature(Signer *signer)

--- a/src/BDoc.cpp
+++ b/src/BDoc.cpp
@@ -29,6 +29,7 @@
 #include "util/File.h"
 #include "util/ZipSerialize.h"
 #include "xml/OpenDocument_manifest.hxx"
+#include "xercesc/util/OutOfMemoryException.hpp"
 
 #include <fstream>
 #include <set>
@@ -490,9 +491,13 @@ void BDoc::parseManifestAndLoadFiles(const ZipSerialize &z, const vector<string>
     {
         THROW("Failed to parse manifest XML: %s (xsd path: %s)", e.what(), Conf::instance()->xsdPath().c_str());
     }
+    catch (const xercesc::OutOfMemoryException& e)
+    {
+        THROW("Failed to parse manifest XML: out of memory");
+    }
     catch (...)
     {
-        THROW("Failed to parse manifest XML: %s", Conf::instance()->xsdPath().c_str());
+        THROW("Failed to parse manifest XML: Unknown exception");
     }
 }
 

--- a/src/util/ZipSerialize.cpp
+++ b/src/util/ZipSerialize.cpp
@@ -148,6 +148,7 @@ void ZipSerialize::extract(const string &file, ostream &os) const
     if(unzResult != UNZ_OK)
         THROW("Failed to open file inside ZIP container. ZLib error: %d", unzResult);
 
+    double currentStreamSize = 0;
     char buf[10240];
     for( ;; )
     {
@@ -159,11 +160,13 @@ void ZipSerialize::extract(const string &file, ostream &os) const
             unzCloseCurrentFile(d->open);
             THROW("Failed to read bytes from current file inside ZIP container. ZLib error: %d", unzResult);
         }
+        currentStreamSize += unzResult;
+
         os.write(buf, unzResult);
         if(os.fail())
         {
             unzCloseCurrentFile(d->open);
-            THROW("Failed to write file '%s' data to stream. ZLib error: %d", file.c_str(), unzResult);
+            THROW("Failed to write file '%s' data to stream. Stream size: %f", file.c_str(), currentStreamSize);
         }
     }
 


### PR DESCRIPTION
If file can not be loaded to memory the error is returned:
  Failed to write file ... data to stream. Stream size: ...

META-INF/manifest.xml file size is not limited. It could be as big as
application/system can handle.

Signed-off-by: Oleg Prokofjev oleg@aktors.ee
