### PR TITLE
Use HTTP header "Last-Modified" for TSL check

### DIFF
--- a/src/crypto/TSL.cpp
+++ b/src/crypto/TSL.cpp
@@ -40,6 +40,7 @@
 #pragma GCC diagnostic pop
 #endif
 
+#include <cmath>
 #include <fstream>
 #include <future>
 
@@ -273,6 +274,10 @@ TSL::Result TSL::parse(const string &url, const vector<X509Cert> &certs,
                     File::removeFile(tmp);
                     tsl = tslnew;
                     valid = true;
+                    
+                    ofstream ots(File::encodeName(path + ".ts").c_str(), ofstream::out|ofstream::trunc);
+                    ots << r.headers["Last-Modified"];
+                    ots.close();
 
                     result = { tsl.certs(), tsl.isExpired() };
                     DEBUG("TSL %s signature is valid", territory.c_str());
@@ -436,6 +441,63 @@ void TSL::validate(const std::vector<X509Cert> &certs)
     }
 }
 
+/// Check if HTTP Last-Modified header is the same as timestamp of the cached TSL
+/// @param url Url of the TSL
+/// @param timeout Time to wait for downloading
+void TSL::validateLastModified(const string &url, int timeout)
+{
+    Connect::Result r = Connect(url, "HEAD", timeout).exec();
+    if(r.isRedirect())
+        r = Connect(r.headers["Location"], "HEAD", timeout).exec();
+    if(r.result.find("200") == string::npos)
+        return;
+    
+    map<string,string>::iterator it = r.headers.find("Last-Modified");
+    if(it != r.headers.end())
+    {
+        string failureReason;
+        DEBUG("Last modified: %s", it->second.c_str());
+        try
+        {
+            tm timestamp = httpTimeToTM(it->second);
+            
+            string line;
+            ifstream is(File::encodeName(path + ".ts"));
+            if(is.is_open())
+            {
+                getline(is, line);
+                DEBUG("Cached timestamp: %s", line.c_str());
+                try
+                {
+                    tm time = httpTimeToTM(line);
+                    if ((int)round(difftime(mkgmtime(timestamp), mkgmtime(time))))
+                    {
+                        failureReason = "Remote timestamp does not match";
+                    }
+                }
+                catch (Exception e)
+                {
+                    failureReason = "Cached timestamp does not exist";
+                }
+            }
+            else
+            {
+                failureReason = "Cached timestamp does not exist";
+            }
+            
+        }
+        catch (Exception e)
+        {
+            WARN("Failed to parse TSL last modified date: %s", e.msg().c_str());
+        }
+        
+        if(!failureReason.empty())
+        {
+            THROW(failureReason.c_str());
+        }
+    }
+}
+
 void TSL::validateRemoteDigest(const std::string &url, int timeout)
 {
     size_t pos = url.find_last_of("/.");
@@ -443,18 +505,34 @@ void TSL::validateRemoteDigest(const std::string &url, int timeout)
         return;
 
     Connect::Result r;
+    bool checkTimestamp = false;
     try
     {
         r= Connect(url.substr(0, pos) + ".sha2", "GET", timeout).exec();
         if(r.isRedirect())
             r = Connect(r.headers["Location"], "GET", timeout).exec();
         if(r.result.find("200") == string::npos)
-            return;
+        {
+            if(r.result.find("404") != string::npos)
+            {
+                checkTimestamp = true;
+            }
+            else
+            {
+                return;
+            }
+        }
     } catch(const Exception &e) {
         debugException(e);
         return DEBUG("Failed to get remote digest %s", url.c_str());
     }
 
+    if(checkTimestamp)
+    {
+        validateLastModified(url, timeout);
+        return;
+    }
+    
     Digest sha(URI_RSA_SHA256);
     vector<unsigned char> buf(10240, 0);
     ifstream is(path, ifstream::binary);

--- a/src/crypto/TSL.cpp
+++ b/src/crypto/TSL.cpp
@@ -475,7 +475,7 @@ void TSL::validateLastModified(const string &url, int timeout)
                         failureReason = "Remote timestamp does not match";
                     }
                 }
-                catch (Exception e)
+                catch(const Exception& e)
                 {
                     failureReason = "Cached timestamp does not exist";
                 }
@@ -486,7 +486,7 @@ void TSL::validateLastModified(const string &url, int timeout)
             }
             
         }
-        catch (Exception e)
+        catch(const Exception& e)
         {
             WARN("Failed to parse TSL last modified date: %s", e.msg().c_str());
         }
@@ -511,17 +511,10 @@ void TSL::validateRemoteDigest(const std::string &url, int timeout)
         r= Connect(url.substr(0, pos) + ".sha2", "GET", timeout).exec();
         if(r.isRedirect())
             r = Connect(r.headers["Location"], "GET", timeout).exec();
-        if(r.result.find("200") == string::npos)
-        {
-            if(r.result.find("404") != string::npos)
-            {
-                checkTimestamp = true;
-            }
-            else
-            {
-                return;
-            }
-        }
+        if(r.result.find("404") != string::npos)
+            checkTimestamp = true;
+        else if(r.result.find("200") == string::npos)
+            return;
     } catch(const Exception &e) {
         debugException(e);
         return DEBUG("Failed to get remote digest %s", url.c_str());

--- a/src/crypto/TSL.cpp
+++ b/src/crypto/TSL.cpp
@@ -444,6 +444,7 @@ void TSL::validate(const std::vector<X509Cert> &certs)
 /// Check if HTTP Last-Modified header is the same as timestamp of the cached TSL
 /// @param url Url of the TSL
 /// @param timeout Time to wait for downloading
+/// @throws Exception if Last-Modified does not match cached ts and TSL loading should be triggered
 void TSL::validateLastModified(const string &url, int timeout)
 {
     Connect::Result r = Connect(url, "HEAD", timeout).exec();

--- a/src/crypto/TSL.h
+++ b/src/crypto/TSL.h
@@ -67,6 +67,7 @@ private:
     static const std::set<std::string> SERVICESTATUS;
 
     std::string toString(const tsl::InternationalNamesType &obj, const std::string &lang = "en") const;
+    void validateLastModified(const std::string &url, int timeout);
     std::shared_ptr<tsl::TrustStatusListType> tsl;
     std::string path;
 };

--- a/src/util/DateTime.cpp
+++ b/src/util/DateTime.cpp
@@ -166,3 +166,39 @@ xml_schema::DateTime digidoc::util::date::makeDateTime(const struct tm& lt)
         0, //zone +0h
         0 ); //zone +0min
 }
+
+/// Convert HTTP date/time stamp to time.
+/// See https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1 for accepted formats.
+///
+/// @param date GMT (UTC) time encoded in RFC 1123, RFC 1036 or ANSI C's asctime() format.
+/// @return decoded time.
+tm digidoc::util::date::httpTimeToTM(const std::string &date)
+{
+    const char* t = date.c_str();
+    
+    // RFC 1123: Sun, 06 Nov 1994 08:49:37 GMT
+    struct tm tm_struct = { };
+    istringstream ss(t);
+    ss.imbue(locale("C"));
+    ss >> get_time(&tm_struct, "%a, %d %b %Y %H:%M:%S GMT");
+    if (ss.fail())
+    {
+        // RFC 1036: Sunday, 06-Nov-94 08:49:37 GMT
+        ss.clear();
+        ss.seekg (0, ss.beg);
+        ss >> get_time(&tm_struct, "%A, %d-%b-%y %H:%M:%S GMT");
+        if (ss.fail())
+        {
+            // ANSI C's asctime(): Sun Nov  6 08:49:37 1994
+            ss.clear();
+            ss.seekg (0, ss.beg);
+            ss >> get_time(&tm_struct, "%A %b %e %H:%M:%S %Y");
+            if (ss.fail())
+            {
+                THROW("Invalid HTTP Full Date format: '%s'", t);
+            }
+        }
+    }
+    
+    return tm_struct;
+}

--- a/src/util/DateTime.cpp
+++ b/src/util/DateTime.cpp
@@ -181,23 +181,23 @@ tm digidoc::util::date::httpTimeToTM(const std::string &date)
     istringstream ss(t);
     ss.imbue(locale("C"));
     ss >> get_time(&tm_struct, "%a, %d %b %Y %H:%M:%S GMT");
+    if (!ss.fail())
+        return tm_struct;
+    
+    // RFC 1036: Sunday, 06-Nov-94 08:49:37 GMT
+    ss.clear();
+    ss.seekg (0, ss.beg);
+    ss >> get_time(&tm_struct, "%A, %d-%b-%y %H:%M:%S GMT");
+    if (!ss.fail())
+        return tm_struct;
+    
+    // ANSI C's asctime(): Sun Nov  6 08:49:37 1994
+    ss.clear();
+    ss.seekg (0, ss.beg);
+    ss >> get_time(&tm_struct, "%A %b %e %H:%M:%S %Y");
     if (ss.fail())
     {
-        // RFC 1036: Sunday, 06-Nov-94 08:49:37 GMT
-        ss.clear();
-        ss.seekg (0, ss.beg);
-        ss >> get_time(&tm_struct, "%A, %d-%b-%y %H:%M:%S GMT");
-        if (ss.fail())
-        {
-            // ANSI C's asctime(): Sun Nov  6 08:49:37 1994
-            ss.clear();
-            ss.seekg (0, ss.beg);
-            ss >> get_time(&tm_struct, "%A %b %e %H:%M:%S %Y");
-            if (ss.fail())
-            {
-                THROW("Invalid HTTP Full Date format: '%s'", t);
-            }
-        }
+        THROW("Invalid HTTP Full Date format: '%s'", t);
     }
     
     return tm_struct;

--- a/src/util/DateTime.h
+++ b/src/util/DateTime.h
@@ -36,6 +36,7 @@ namespace digidoc
             std::string xsd2string(const xml_schema::DateTime &time);
             time_t string2time_t(const std::string &time);
             xml_schema::DateTime makeDateTime(const struct tm &lt);
+            tm httpTimeToTM(const std::string &date);
         }
     }
 }

--- a/test/libdigidocpp_boost.cpp
+++ b/test/libdigidocpp_boost.cpp
@@ -627,3 +627,27 @@ BOOST_AUTO_TEST_CASE(OpenInvalidMimetypeContainer)
     BOOST_CHECK_THROW(Container::open("test-invalid.asics"), Exception);
 }
 BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(DateUtilSuite)
+BOOST_AUTO_TEST_CASE(HttpDateToTm) {
+    
+    const vector<string> timestamps = {
+        "Sun, 06 Nov 1994 08:49:37 GMT",
+        "Sunday, 06-Nov-94 08:49:37 GMT",
+        "Sun Nov  6 08:49:37 1994"
+    };
+    
+    for(const string &timestamp: timestamps) {
+        const tm ts = digidoc::util::date::httpTimeToTM(timestamp);
+        BOOST_CHECK_EQUAL(1994, ts.tm_year + 1900);
+        BOOST_CHECK_EQUAL(11, ts.tm_mon + 1);
+        BOOST_CHECK_EQUAL(6, ts.tm_mday);
+        
+        BOOST_CHECK_EQUAL(8, ts.tm_hour);
+        BOOST_CHECK_EQUAL(49, ts.tm_min);
+        BOOST_CHECK_EQUAL(37, ts.tm_sec);
+    }
+    
+    BOOST_CHECK_THROW(digidoc::util::date::httpTimeToTM("-Nov-94 08:49:37 GMT"), Exception); // wrong date
+}
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
IB-4224: Use HTTP header "Last-Modified" for checking if TSL is updated when
sha2 digest does not exist. If checksum is not present, fetch headers and check
if cached timestamp matches remote "Last-Modified" header.
Download whole TSL if timestamp does not match or timestamp is not cached.
Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>