### PR TITLE
Use dedicated status to indicate nonQSCD signature

### DIFF
--- a/libdigidocpp.dox
+++ b/libdigidocpp.dox
@@ -1084,6 +1084,12 @@ i.e. no signatures should be added or removed.</td>
 </tr>
 <tr>
   <td>4</td>
+  <td>RESTRICTED</td>
+  <td><b>17</b> QSCDConformanceWarning (signature is not given with qualified signature creation device)</td>
+  <td>Validation process determines that signature is not given with qualified signature creation device (QSCD). QSCD is according to eIDAS a device, which has Common Criteria (CC) certificate with Protection Profile for SSCD (see Standard EN 419 211, Protection Profiles for Secure Signature Creation and other related devices part 1-2).</td>
+</tr>
+<tr>
+  <td>5</td>
   <td>VALID</td>
   <td>N/A</td>
   <td>Validation process returns no errors. The signature is legally valid.</td>

--- a/src/Exception.h
+++ b/src/Exception.h
@@ -53,6 +53,7 @@ namespace digidoc
               DataFileNameSpaceWarning = 14,
               IssuerNameSpaceWarning   = 15,
               ProducedATLateWarning     = 16,
+              QSCDConformanceWarning   = 17,
               //DDoc error codes
               DDocError                = 512
           };

--- a/src/SignatureXAdES_B.cpp
+++ b/src/SignatureXAdES_B.cpp
@@ -698,6 +698,7 @@ void SignatureXAdES_B::checkKeyInfo() const
  */
 void SignatureXAdES_B::checkSigningCertificate(bool noqscd) const
 {
+    bool qscdWarning = false;
     try
     {
         X509Cert signingCert = signingCertificate();
@@ -705,11 +706,18 @@ void SignatureXAdES_B::checkSigningCertificate(bool noqscd) const
         if(find(usage.begin(), usage.end(), X509Cert::NonRepudiation) == usage.end())
             THROW("Signing certificate does not contain NonRepudiation key usage flag");
         if(!X509CertStore::instance()->verify(signingCert, noqscd))
-            THROW("Unable to verify signing certificate");
+            qscdWarning = true;
     }
     catch(const Exception &e)
     {
         THROW_CAUSE( e, "Unable to verify signing certificate" );
+    }
+
+    if(qscdWarning)
+    {
+        Exception e(EXCEPTION_PARAMS("Signing certificate does not meet Qualification requirements"));
+        e.setCode(Exception::QSCDConformanceWarning);
+        throw e;
     }
 }
 

--- a/src/crypto/X509CertStore.cpp
+++ b/src/crypto/X509CertStore.cpp
@@ -336,12 +336,7 @@ bool X509CertStore::verify(const X509Cert &cert, bool noqscd) const
             }
         }
 
-        if(!isQCCompliant || !isQSCD)
-        {
-            return false;
-        }
-
-        return true;
+        return isQCCompliant && isQSCD;
     }
 
     int err = X509_STORE_CTX_get_error(csc.get());

--- a/src/crypto/X509CertStore.cpp
+++ b/src/crypto/X509CertStore.cpp
@@ -251,6 +251,7 @@ int X509CertStore::validate(int ok, X509_STORE_CTX *ctx, const set<string> &type
 
 /**
  * Check if X509Cert is signed by trusted issuer
+ * @return false if QSCD check fails
  * @throw Exception if error
  */
 bool X509CertStore::verify(const X509Cert &cert, bool noqscd) const
@@ -337,9 +338,7 @@ bool X509CertStore::verify(const X509Cert &cert, bool noqscd) const
 
         if(!isQCCompliant || !isQSCD)
         {
-            Exception e(EXCEPTION_PARAMS("Signing certificate does not meet Qualification requirements"));
-            e.setCode(Exception::CertificateIssuerMissing);
-            throw e;
+            return false;
         }
 
         return true;

--- a/src/digidoc-tool.cpp
+++ b/src/digidoc-tool.cpp
@@ -469,6 +469,7 @@ static void parseException(const Exception &e, const char *main = 0)
     case Exception::PINLocked: cout << "PINLocked"; break;
     case Exception::ReferenceDigestWeak: cout << "ReferenceDigestWeak"; break;
     case Exception::SignatureDigestWeak: cout << "SignatureDigestWeak"; break;
+    case Exception::QSCDConformanceWarning: cout << "QSCDConformanceWarning"; break;
     case Exception::DataFileNameSpaceWarning: cout << "DataFileNameSpaceWarning"; break;
     case Exception::IssuerNameSpaceWarning: cout << "IssuerNameSpaceWarning"; break;
     case Exception::ProducedATLateWarning: cout << "ProducedATLateWarning"; break;
@@ -588,6 +589,7 @@ static int open(int argc, char* argv[])
                         {
                         case Exception::ReferenceDigestWeak: warnings.push_back("ReferenceDigestWeak"); break;
                         case Exception::SignatureDigestWeak: warnings.push_back("SignatureDigestWeak"); break;
+                        case Exception::QSCDConformanceWarning: warnings.push_back("QSCDConformanceWarning"); break;
                         case Exception::IssuerNameSpaceWarning:
                         case Exception::DataFileNameSpaceWarning: warnings.push_back("WrongNameSpace"); break;
                         case Exception::ProducedATLateWarning: warnings.push_back("ProducedATLate"); break;


### PR DESCRIPTION
IB-4737: Use enum value ExceptionCode::QSCDConformanceWarning to indicate nonQSCD signatures instead of CertificateIssuerMissing.
The commit is pre-requisite for https://github.com/open-eid/qdigidoc/commit/bdaf3ecd6a380c36e5a16d4384dbb758f120f915
Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>