### PR TITLE
Converted AUTHORS encoding from ISO-8859-1 to UTF-8

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,6 @@
 Andrus Randveer
 Vambola Kotkas
-Janari Põld
+Janari PÃµld
 Janno Kusman
 Raul Metsma <raul@metsma.ee>
 Kalev Lember


### PR DESCRIPTION
In [libdigidocpp Fedora package review](https://bugzilla.redhat.com/show_bug.cgi?id=1519747) reviewer Robert-André Mauchin found out that AUTHORS file encoding is ISO-8859-1 instead of UTF-8, so [I used iconv to convert it](https://fedoraproject.org/wiki/Packaging_tricks#Convert_encoding_to_UTF-8)