### PR TITLE
Converted COPYING encoding from ISO-8859-1 to UTF-8

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -21,8 +21,8 @@ etc/schema/OpenDocument_manifest.rng
 	OASIS standard, 1 May 2005
 	Relax-NG Manifest Schema
 	$Id$
-	© 2002-2005 OASIS Open
-	© 1999-2005 Sun Microsystems, Inc.
+	Â© 2002-2005 OASIS Open
+	Â© 1999-2005 Sun Microsystems, Inc.
 
 _______________________________________________________________________________
 src/minizip


### PR DESCRIPTION
In [libdigidocpp Fedora package review](https://bugzilla.redhat.com/show_bug.cgi?id=1519749) reviewer Robert-André Mauchin found out that COPYING file encoding is ISO-8859-1 instead of UTF-8, so [I used iconv to convert it](https://fedoraproject.org/wiki/Packaging_tricks#Convert_encoding_to_UTF-8)