### PR TITLE
Fix LGTM warning

### DIFF
--- a/src/jsonxx.cc
+++ b/src/jsonxx.cc
@@ -1127,6 +1127,13 @@ Array &Array::operator=(const Value &value) {
 Value::Value(const Value &other) : type_(INVALID_) {
   import( other );
 }
+Value &Value::operator=(const Value &other) {
+  if( this != &other ) {
+    reset();
+    import(other);
+  }
+  return *this;
+}
 bool Value::empty() const {
   if( type_ == INVALID_ ) return true;
   if( type_ == STRING_ && string_value_ == 0 ) return true;

--- a/src/jsonxx.h
+++ b/src/jsonxx.h
@@ -282,6 +282,7 @@ class Value {
     import(t);
     return *this;
   }
+  Value &operator =( const Value &other );
   Value(const Value &other);
   template<typename T>
   Value( const T&t ) : type_(INVALID_) { import(t); }


### PR DESCRIPTION
Inconsistent definition of copy constructor and assignment ('Rule of Two')

IB-5912

Signed-off-by: Raul Metsma <raul@metsma.ee>