### PR TITLE
Workaround macOS hiding xml-security symbols

### DIFF
--- a/prepare_osx_build_environment.sh
+++ b/prepare_osx_build_environment.sh
@@ -182,6 +182,9 @@ function xml_security {
     tar xf ${XMLSEC_DIR}.tar.gz
     cd ${XMLSEC_DIR}
     sed -ie 's!as_fn_error $? "cannot run test program while cross compiling!$as_echo_n "cannot run test program while cross compiling!' configure
+    sed -ie 's!#define XSEC_EXPORT!#define XSEC_EXPORT __attribute__ ((visibility("default")))!' xsec/framework/XSECDefs.hpp
+    CFLAGS="${CFLAGS} -fvisibility=hidden" \
+    CXXFLAGS="${CXXFLAGS} -fvisibility=hidden -fvisibility-inlines-hidden" \
     xerces_CFLAGS="-I${TARGET_PATH}/include" xerces_LIBS="-L${TARGET_PATH}/lib -lxalanMsg -lxalan-c -lxerces-c" \
     openssl_CFLAGS="-I${TARGET_PATH}/include" openssl_LIBS="-L${TARGET_PATH}/lib -lcrypto" \
     ./configure --prefix=${TARGET_PATH} ${CONFIGURE} --with-xalan=${TARGET_PATH}

--- a/src/SignatureXAdES_LTA.cpp
+++ b/src/SignatureXAdES_LTA.cpp
@@ -41,6 +41,12 @@ DIGIDOCPP_WARNING_DISABLE_MSVC(4005)
 #include <xsec/utils/XSECBinTXFMInputStream.hpp>
 DIGIDOCPP_WARNING_POP
 
+#if XSEC_VERSION_MAJOR < 2
+#define XSEC_CONST
+#else
+#define XSEC_CONST const
+#endif
+
 using namespace digidoc;
 using namespace digidoc::dsig;
 using namespace digidoc::util;
@@ -91,7 +97,7 @@ void SignatureXAdES_LTA::calcArchiveDigest(Digest *digest) const
     catch(const xsd::cxx::xml::invalid_utf16_string & /* ex */) {
         THROW("Failed to calculate digest");
     }
-    catch(XSECException &e)
+    catch(XSEC_CONST XSECException &e)
     {
         try {
             string result = xsd::cxx::xml::transcode<char>(e.getMsg());
@@ -177,15 +183,15 @@ TS SignatureXAdES_LTA::tsaFromBase64() const
 {
     try {
         if(unsignedSignatureProperties().archiveTimeStampV141().empty())
-            return TS();
+            return {};
         const xadesv141::ArchiveTimeStampType &ts = unsignedSignatureProperties().archiveTimeStampV141().front();
         if(ts.encapsulatedTimeStamp().empty())
-            return TS();
+            return {};
         const GenericTimeStampType::EncapsulatedTimeStampType &bin =
                 ts.encapsulatedTimeStamp().front();
         return TS((const unsigned char*)bin.data(), bin.size());
     } catch(const Exception &) {}
-    return TS();
+    return {};
 }
 
 X509Cert SignatureXAdES_LTA::ArchiveTimeStampCertificate() const

--- a/src/crypto/TSL.cpp
+++ b/src/crypto/TSL.cpp
@@ -41,6 +41,12 @@ DIGIDOCPP_WARNING_POP
 #include <fstream>
 #include <future>
 
+#if XSEC_VERSION_MAJOR < 2
+#define XSEC_CONST
+#else
+#define XSEC_CONST const
+#endif
+
 using namespace digidoc;
 using namespace digidoc::tsl;
 using namespace digidoc::util;
@@ -400,7 +406,7 @@ bool TSL::parseInfo(const Info &info, Service &s, time_t &previousTime)
         if(!id.x509Certificate().present())
             continue;
         const Base64Binary &base64 = id.x509Certificate().get();
-        s.certs.emplace_back(X509Cert((const unsigned char*)base64.data(), base64.size()));
+        s.certs.emplace_back((const unsigned char*)base64.data(), base64.size());
     }
 
     if(SERVICESTATUS_START.find(info.serviceStatus()) != SERVICESTATUS_START.cend())
@@ -436,13 +442,13 @@ std::vector<TSL::Pointer> TSL::pointers() const
                         continue;
                     const Base64Binary &base64 = id.x509Certificate().get();
                     try {
-                        p.certs.emplace_back(X509Cert((const unsigned char*)base64.data(), base64.size()));
+                        p.certs.emplace_back((const unsigned char*)base64.data(), base64.size());
                         continue;
                     } catch(const Exception &e) {
                         DEBUG("Failed to parse %s certificate, Testing also parse as PEM: %s", p.territory.c_str(), e.msg().c_str());
                     }
                     try {
-                        p.certs.emplace_back(X509Cert((const unsigned char*)base64.data(), base64.size(), X509Cert::Pem));
+                        p.certs.emplace_back((const unsigned char*)base64.data(), base64.size(), X509Cert::Pem);
                     } catch(const Exception &e) {
                         DEBUG("Failed to parse %s certificate as PEM: %s", p.territory.c_str(), e.msg().c_str());
                     }
@@ -525,7 +531,7 @@ void TSL::validate(const std::vector<X509Cert> &certs)
             }
         }
     }
-    catch(XSECException &e)
+    catch(XSEC_CONST XSECException &e)
     {
         try {
             string result = xsd::cxx::xml::transcode<char>(e.getMsg());


### PR DESCRIPTION
IB-6667

Signed-off-by: Raul Metsma <raul@metsma.ee>