### PR TITLE
AddDataFile checks

### DIFF
--- a/src/ASiC_E.h
+++ b/src/ASiC_E.h
@@ -33,7 +33,7 @@ namespace digidoc
      * not signed. To add or remove documents from signed container remove all the
      * signatures before modifying documents list in container.
      */
-    class ASiC_E: public ASiContainer
+    class ASiC_E final : public ASiContainer
     {
       public:
           static const std::string BES_PROFILE;
@@ -45,12 +45,12 @@ namespace digidoc
           static const std::string MANIFEST_NAMESPACE;
 
           ~ASiC_E() final;
-          void save(const std::string &path = "") override;
+          void save(const std::string &path = {}) final;
           std::vector<DataFile*> metaFiles() const;
 
-          void addAdESSignature(std::istream &sigdata) override;
-          Signature* prepareSignature(Signer *signer) override;
-          Signature* sign(Signer* signer) override;
+          void addAdESSignature(std::istream &sigdata) final;
+          Signature* prepareSignature(Signer *signer) final;
+          Signature* sign(Signer* signer) final;
 
           static std::unique_ptr<Container> createInternal(const std::string &path);
           static std::unique_ptr<Container> openInternal(const std::string &path);

--- a/src/ASiContainer.h
+++ b/src/ASiContainer.h
@@ -57,26 +57,13 @@ namespace digidoc
           void addDataFile(std::unique_ptr<std::istream> is, const std::string &fileName, const std::string &mediaType) override;
           std::vector<DataFile*> dataFiles() const override;
           void removeDataFile(unsigned int id) override;
-
-          template <class T>
-          Signature* newSignature(Signer *signer)
-          {
-              if(dataFiles().empty())
-                  THROW("No documents in container, can not sign container.");
-              if(!signer)
-                  THROW("Null pointer in ASiC_E::sign");
-                
-              T *signature = new T(newSignatureId(), this, signer);
-              addSignature(signature);
-              return signature;
-          }
-        
           void removeSignature(unsigned int id) override;
           std::vector<Signature*> signatures() const override;
 
       protected:
           ASiContainer(const std::string &mimetype);
 
+          void addDataFilePrivate(std::unique_ptr<std::istream> is, const std::string &fileName, const std::string &mediaType);
           void addSignature(Signature *signature);
           std::unique_ptr<std::iostream> dataStream(const std::string &path, const ZipSerialize &z) const;
           std::unique_ptr<ZipSerialize> load(const std::string &path, bool requireMimetype, const std::set<std::string> &supported);
@@ -92,9 +79,9 @@ namespace digidoc
       private:
           DISABLE_COPY(ASiContainer);
 
+          void addDataFileChecks(const std::string &path, const std::string &mediaType);
+
           class Private;
           Private *d;
     };
 }
-
-#define MAX_MEM_FILE 500*1024*1024

--- a/test/libdigidocpp_boost.cpp
+++ b/test/libdigidocpp_boost.cpp
@@ -166,6 +166,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(constructor, Doc, DocTypes)
     BOOST_CHECK_EQUAL(d->dataFiles().size(), 0U);
     BOOST_CHECK_EQUAL(d->signatures().size(), 0U);
     BOOST_CHECK_EQUAL(d->mediaType(), Doc::TYPE);
+    BOOST_CHECK_THROW(d->addDataFile("mimetype", "text/plain"), Exception);
+    BOOST_CHECK_THROW(d->addDataFile("test.txt", "textplain"), Exception);
+    BOOST_CHECK_THROW(d->addDataFile(std::unique_ptr<std::istream>(new stringstream), "folder/test.txt", "text/plain"), Exception);
+    BOOST_CHECK_THROW(d->addDataFile("test.txt", "text/plain"), Exception);
+    BOOST_CHECK_NO_THROW(d->addDataFile("test1.txt", "text/plain"));
+    BOOST_CHECK_THROW(d->addDataFile("test1.txt", "text/plain"), Exception);
 
     d = Container::openPtr("test." + Doc::EXT);
     if(!d)


### PR DESCRIPTION
- don't allow filename 'mimetype'
- don't allow filename with path
- check mediatype format

Fixes #375, IB-6708

Signed-off-by: Raul Metsma <raul@metsma.ee>