### PR TITLE
digidoc-tool.1: Use actual PKCS11 module path

### DIFF
--- a/src/digidoc-tool.1.cmake
+++ b/src/digidoc-tool.1.cmake
@@ -56,7 +56,7 @@ Command sign:
     --postalCode=  - postalCode of production place
     --country=     - country of production place
     --role=        - option can occur multiple times. Signer role(s)
-    --pkcs11[=]    - default is /Library/OpenSC/lib/opensc-pkcs11.so. Path of PKCS11 driver.
+    --pkcs11[=]    - default is ${PKCS11_MODULE}. Path of PKCS11 driver.
     --pkcs12=      - pkcs12 signer certificate (use --pin for password)
     --pin=         - default asks pin from prompt
     --sha(224,256,384,512) - set default digest method (default sha256)


### PR DESCRIPTION
On Linux and BSD, the macOS default is certainly wrong.

Use the variable populated by CMake to reflect the actually used path
in the manual.

This properly shows the following on OpenBSD:
    --pkcs11[=]    - default is /usr/local/lib/pkcs11/opensc-pkcs11.so. Path of PKCS11 driver.

Signed-off-by: Klemens Nanni <klemens@posteo.de>