### PR TITLE
Fix building against LibreSSL

### DIFF
--- a/src/crypto/Digest.cpp
+++ b/src/crypto/Digest.cpp
@@ -128,10 +128,12 @@ void Digest::reset(const string &uri)
     case NID_sha256: result = EVP_DigestInit(d->ctx, EVP_sha256()); break;
     case NID_sha384: result = EVP_DigestInit(d->ctx, EVP_sha384()); break;
     case NID_sha512: result = EVP_DigestInit(d->ctx, EVP_sha512()); break;
+#ifndef LIBRESSL_VERSION_NUMBER
     case NID_sha3_224: result = EVP_DigestInit(d->ctx, EVP_sha3_224()); break;
     case NID_sha3_256: result = EVP_DigestInit(d->ctx, EVP_sha3_256()); break;
     case NID_sha3_384: result = EVP_DigestInit(d->ctx, EVP_sha3_384()); break;
     case NID_sha3_512: result = EVP_DigestInit(d->ctx, EVP_sha3_512()); break;
+#endif
     default: break;
     }
     d->clear();
@@ -165,10 +167,12 @@ int Digest::toMethod(const string &uri)
     if(uri == URI_SHA256 || uri == URI_RSA_SHA256 || uri == URI_RSA_PSS_SHA256 || uri == URI_ECDSA_SHA256) return NID_sha256;
     if(uri == URI_SHA384 || uri == URI_RSA_SHA384 || uri == URI_RSA_PSS_SHA384 || uri == URI_ECDSA_SHA384) return NID_sha384;
     if(uri == URI_SHA512 || uri == URI_RSA_SHA512 || uri == URI_RSA_PSS_SHA512 || uri == URI_ECDSA_SHA512) return NID_sha512;
+#ifndef LIBRESSL_VERSION_NUMBER
     if(uri == URI_SHA3_224 || uri == URI_RSA_PSS_SHA3_224) return NID_sha3_224;
     if(uri == URI_SHA3_256 || uri == URI_RSA_PSS_SHA3_256) return NID_sha3_256;
     if(uri == URI_SHA3_384 || uri == URI_RSA_PSS_SHA3_384) return NID_sha3_384;
     if(uri == URI_SHA3_512 || uri == URI_RSA_PSS_SHA3_512) return NID_sha3_512;
+#endif
     THROW( "Digest method URI '%s' is not supported.", uri.c_str() );
 }
 
@@ -188,10 +192,14 @@ string Digest::toRsaUri(const string &uri)
         uri == URI_RSA_PSS_SHA256 ||
         uri == URI_RSA_PSS_SHA384 ||
         uri == URI_RSA_PSS_SHA512 ||
+#ifndef LIBRESSL_VERSION_NUMBER
         uri == URI_RSA_PSS_SHA3_224 ||
         uri == URI_RSA_PSS_SHA3_256 ||
         uri == URI_RSA_PSS_SHA3_384 ||
         uri == URI_RSA_PSS_SHA3_512)
+#else
+        0)
+#endif
         return uri;
     return {};
 }
@@ -234,10 +242,12 @@ std::string Digest::toUri(int nid)
     case NID_sha256: return URI_SHA256;
     case NID_sha384: return URI_SHA384;
     case NID_sha512: return URI_SHA512;
+#ifndef LIBRESSL_VERSION_NUMBER
     case NID_sha3_224: return URI_SHA3_224;
     case NID_sha3_256: return URI_SHA3_256;
     case NID_sha3_384: return URI_SHA3_384;
     case NID_sha3_512: return URI_SHA3_512;
+#endif
     default: return {};
     }
 }

--- a/src/crypto/OpenSSLHelpers.h
+++ b/src/crypto/OpenSSLHelpers.h
@@ -67,12 +67,14 @@ class OpenSSLException : public Exception
             while((error = ERR_get_error()) != 0)
             {
                 Exception e(ERR_lib_error_string(error), 0, ERR_error_string(error, nullptr));
+#ifndef LIBRESSL_VERSION_NUMBER
                 if(ERR_GET_LIB(error) == ERR_R_BIO_LIB &&
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
                     ERR_GET_FUNC(error) == BIO_F_BIO_LOOKUP_EX &&
 #endif
                     ERR_GET_REASON(error) == ERR_R_SYS_LIB)
                     e.setCode(ExceptionCode::HostNotFound);
+#endif
                 addCause(e);
             }
         }

--- a/src/crypto/TS.cpp
+++ b/src/crypto/TS.cpp
@@ -40,6 +40,38 @@
 using namespace digidoc;
 using namespace std;
 
+#if defined(LIBRESSL_VERSION_NUMBER)
+void *OPENSSL_memdup(const void *data, size_t size)
+{
+	void *copy;
+
+	if (data == NULL || size == 0 || size >= INT_MAX)
+		return NULL;
+
+	if ((copy = malloc(size)) == NULL)
+		return NULL;
+
+	return memcpy(copy, data, size);
+}
+
+static void TS_VERIFY_CTX_set_flags(TS_VERIFY_CTX *ctx, int f)
+{
+    ctx->flags = unsigned(f);
+}
+
+static void TS_VERIFY_CTX_set_imprint(TS_VERIFY_CTX *ctx, unsigned char *hexstr, long len)
+{
+    OPENSSL_free(ctx->imprint);
+    ctx->imprint = hexstr;
+    ctx->imprint_len = unsigned(len);
+}
+
+static void TS_VERIFY_CTX_set_store(TS_VERIFY_CTX *ctx, X509_STORE *s)
+{
+    ctx->store = s;
+}
+#endif
+
 TS::TS(const string &url, const Digest &digest, const string &useragent)
 {
     SCOPE(TS_REQ, req, TS_REQ_new());

--- a/src/crypto/X509Cert.cpp
+++ b/src/crypto/X509Cert.cpp
@@ -74,7 +74,13 @@ DECLARE_ASN1_FUNCTIONS(QCStatement)
  * QCStatements ::= SEQUENCE OF QCStatement
  */
 using QCStatements = STACK_OF(QCStatement);
+#ifdef LIBRESSL_VERSION_NUMBER
+#include <openssl/safestack.h>
+#define sk_QCStatement_num(st) sk_num((_STACK*)st)
+#define sk_QCStatement_value(st, i) (QCStatement*)sk_value((_STACK*)st, i)
+#else
 DEFINE_STACK_OF(QCStatement)
+#endif
 DECLARE_ASN1_FUNCTIONS(QCStatements)
 
 /**

--- a/src/crypto/X509Crypto.cpp
+++ b/src/crypto/X509Crypto.cpp
@@ -37,6 +37,7 @@
 using namespace digidoc;
 using namespace std;
 
+#ifndef LIBRESSL_VERSION_NUMBER
 /*-
  * IssuerSerial ::= SEQUENCE {
  *         issuer                   GeneralNames,
@@ -47,6 +48,7 @@ using ESS_ISSUER_SERIAL = struct ESS_issuer_serial {
     GENERAL_NAMES *issuer;
     ASN1_INTEGER *serial;
 };
+#endif
 
 /**
  * Initialize RSA crypter.


### PR DESCRIPTION
With the upcoming 3.6 release LibreSSL will ship
`X509_VERIFY_PARAM_get_time()` as required by libdigidocpp.

Furthermore, the following changes are required to build latest HEAD against
current LibreSSL:

- Omit SHA3 with LibreSSL
- Omit BIO_F_BIO_LOOKUP_EX handling with LibreSSL
- Provide OPENSSL_memdup() and TS accessors with LibreSSL
- Use old-style STACK_OF stuff for LibreSSL
- Do not define ESS_ISSUER_SERIAL with LibreSSL

All patches patches were written by @botovq against the 3.14.8 release during
review of my OpenBSD ports/package submission for libdigidocpp[0].

I rebased the patches onto latest HEAD (d9fd053) and retested on
OpenBSD/amd64 7.1 -CURRENT, i.e. today's latest LibreSSL development version.

0: https://github.com/openbsd/ports/commit/a015763b93d663421e15e7f233ae3ee7ed89b8c2