### PR TITLE
Preserve OpenSSL exception in TS validation error path

### DIFF
--- a/src/crypto/TS.cpp
+++ b/src/crypto/TS.cpp
@@ -242,7 +242,7 @@ void TS::verify(const Digest &digest)
         TS_VERIFY_CTX_set_store(ctx.get(), store.release());
         if(TS_RESP_verify_token(ctx.get(), d.get()) != 1)
         {
-            unsigned long err = ERR_get_error();
+            unsigned long err = ERR_peek_error();
             if(ERR_GET_LIB(err) == ERR_LIB_TS && ERR_GET_REASON(err) == TS_R_CERTIFICATE_VERIFY_ERROR)
             {
                 Exception e(EXCEPTION_PARAMS("Certificate status: unknown"));


### PR DESCRIPTION
if `TS_RESP_verify_token()` fails, ERR_get_error(3) is used to check for
a specific error reason and throw a specific exception.

But in case of different reasons, the generic `THROW_OPENSSLEXCEPTION()`
is used which itself ERR_get_error(3), at which point the actual error
has already been removed from the thread's error queue.

Use ERR_peek_error(3) for special casing the specific error instead,
such that the queue remains unmodified and `THROW_OPENSSLEXCEPTION()` is
able to show the actual error.

This results in the following error diff in case of TS valdiation errors
(as can be seen on OpenBSD when built LibreSSL):

```
$ digidoc-tool create --file=./hello.txt ./hello.asice
Version
  digidoc-tool version: 3.14.8.0
  libdigidocpp version: 3.14.8.0
Available certificates:
  label: NANNI,KLEMENS ANTONIUS,39311290189
Selected:
  label: NANNI,KLEMENS ANTONIUS,39311290189
    Validation: [31mFAILED[0m
     Exception:
SignatureXAdES_LTA.cpp:203 code(General) Signature validation
TS.cpp:288 code(General) Failed to verify TS response.
```

With this diff, the following line will be added at the end:
```
time stamp routines:0 code(General) error:2FFFF065:time stamp routines:CRYPTO_internal:ess signing certificate error
```

Signed-off-by: Klemens Nanni <klemens@posteo.de>

See https://github.com/open-eid/libdigidocpp/pull/482#issuecomment-1179837291

