### PR TITLE
LibreSSL: opaque TS structs, 3.6.0 provides TS accessors

### DIFF
--- a/src/crypto/TS.cpp
+++ b/src/crypto/TS.cpp
@@ -53,23 +53,6 @@ void *OPENSSL_memdup(const void *data, size_t size)
 
 	return memcpy(copy, data, size);
 }
-
-static void TS_VERIFY_CTX_set_flags(TS_VERIFY_CTX *ctx, int f)
-{
-    ctx->flags = unsigned(f);
-}
-
-static void TS_VERIFY_CTX_set_imprint(TS_VERIFY_CTX *ctx, unsigned char *hexstr, long len)
-{
-    OPENSSL_free(ctx->imprint);
-    ctx->imprint = hexstr;
-    ctx->imprint_len = unsigned(len);
-}
-
-static void TS_VERIFY_CTX_set_store(TS_VERIFY_CTX *ctx, X509_STORE *s)
-{
-    ctx->store = s;
-}
 #endif
 
 TS::TS(const string &url, const Digest &digest, const string &useragent)

--- a/src/crypto/X509Crypto.cpp
+++ b/src/crypto/X509Crypto.cpp
@@ -37,7 +37,6 @@
 using namespace digidoc;
 using namespace std;
 
-#ifndef LIBRESSL_VERSION_NUMBER
 /*-
  * IssuerSerial ::= SEQUENCE {
  *         issuer                   GeneralNames,
@@ -48,7 +47,6 @@ using ESS_ISSUER_SERIAL = struct ESS_issuer_serial {
     GENERAL_NAMES *issuer;
     ASN1_INTEGER *serial;
 };
-#endif
 
 /**
  * Initialize RSA crypter.


### PR DESCRIPTION
See LibreSSL 3.6.0 (October 5th, 2022) changelog:
https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.6.0-relnotes.txt

Courtesy of Theo Buehler < tb AT openbsd DOT org>, who provided these
fixes as local ports patches;  I merely upstream them.
