### PR TITLE
Workaround MSVC 2019 issue

### DIFF
--- a/libdigidocpp.wxs
+++ b/libdigidocpp.wxs
@@ -83,6 +83,7 @@
                   <File Name="xml.xsd"/>
                   <File Name="conf.xsd"/>
                   <File Name="OpenDocument_manifest.xsd"/>
+                  <File Name="OpenDocument_manifest_v1_2.xsd"/>
                   <File Name="xmldsig-core-schema.xsd"/>
                   <File Name="XAdES01903v132-201601.xsd"/>
                   <File Name="XAdES01903v132-201601-relaxed.xsd"/>
@@ -147,6 +148,7 @@
                   <File Name="xml.xsd" Id="xml.xsd_64"/>
                   <File Name="conf.xsd" Id="conf.xsd_64"/>
                   <File Name="OpenDocument_manifest.xsd" Id="OpenDocument_manifest.xsd_64"/>
+                  <File Name="OpenDocument_manifest_v1_2.xsd" Id="OpenDocument_manifest_v1_2.xsd_64"/>
                   <File Name="xmldsig-core-schema.xsd" Id="xmldsig_core_schema.xsd_64"/>
                   <File Name="XAdES01903v132-201601.xsd" Id="XAdES01903v132_201601.xsd_64"/>
                   <File Name="XAdES01903v132-201601-relaxed.xsd" Id="XAdES01903v132_201601_relaxed.xsd_64"/>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,6 +140,9 @@ set( CRYPTO_HEADER
     crypto/X509Cert.h
 )
 
+add_library(digidocpp_ver INTERFACE)
+target_sources(digidocpp_ver INTERFACE libdigidocpp.rc)
+
 add_library(digidocpp_util STATIC
     util/File.cpp
     util/log.cpp
@@ -192,7 +195,6 @@ add_library(digidocpp
     ${PUBLIC_HEADER}
     ${CRYPTO_HEADER}
     ${XML_HEADER}
-    libdigidocpp.rc
     Container.cpp
     ASiContainer.cpp
     ASiC_E.cpp
@@ -238,10 +240,11 @@ set_target_properties(digidocpp PROPERTIES
     FRAMEWORK "${FRAMEWORK}"
     MACOSX_FRAMEWORK_IDENTIFIER "ee.ria.digidocpp"
     MACOSX_RPATH YES
+    COMPILE_DEFINITIONS TARGET_NAME="$<TARGET_NAME:digidocpp>"
 )
 
 target_include_directories(digidocpp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(digidocpp PRIVATE ${CMAKE_DL_LIBS} minizip digidocpp_priv)
+target_link_libraries(digidocpp PRIVATE ${CMAKE_DL_LIBS} minizip digidocpp_priv digidocpp_ver)
 
 if( BUILD_TOOLS )
     add_executable(digidoc-tool digidoc-tool.rc digidoc-tool.cpp)
@@ -270,7 +273,8 @@ if(SWIG_FOUND)
         set(CMAKE_SWIG_OUTDIR ${CMAKE_CURRENT_BINARY_DIR}/java)
         swig_add_library(digidoc_java TYPE SHARED LANGUAGE java SOURCES ../libdigidocpp.i)
         target_include_directories(digidoc_java PRIVATE ${JAVA_INCLUDE_PATH} $<$<BOOL:${JAVA_INCLUDE_PATH2}>:${JAVA_INCLUDE_PATH2}>)
-        target_link_libraries(digidoc_java digidocpp digidocpp_util)
+        target_compile_definitions(digidoc_java PRIVATE TARGET_NAME="$<TARGET_NAME:digidoc_java>")
+        target_link_libraries(digidoc_java digidocpp digidocpp_util digidocpp_ver)
         if(APPLE)
             set_target_properties(digidoc_java PROPERTIES MACOSX_RPATH YES INSTALL_RPATH /Library/Frameworks)
             install(TARGETS digidoc_java DESTINATION /Library/Java/Extensions)
@@ -286,7 +290,8 @@ if(SWIG_FOUND)
         set(CMAKE_SWIG_FLAGS -py3)
         set(CMAKE_SWIG_OUTDIR ${CMAKE_CURRENT_BINARY_DIR})
         swig_add_library(digidoc_python TYPE SHARED LANGUAGE python SOURCES ../libdigidocpp.i)
-        target_link_libraries(digidoc_python digidocpp digidocpp_util Python3::Module)
+        target_compile_definitions(digidoc_python PRIVATE TARGET_NAME="$<TARGET_NAME:digidoc_python>")
+        target_link_libraries(digidoc_python digidocpp digidocpp_util digidocpp_ver Python3::Module)
         #configure_file(setup.py.cmake setup.py)
         #install(CODE "execute_process(COMMAND python3 ${CMAKE_CURRENT_BINARY_DIR}/setup.py install)")
         if(NOT Python3_SITELIB)
@@ -307,7 +312,8 @@ if(SWIG_FOUND)
         set(CMAKE_SWIG_FLAGS -dllimport digidoc_csharp -namespace digidoc)
         set(CMAKE_SWIG_OUTDIR ${CMAKE_CURRENT_BINARY_DIR}/csharp)
         swig_add_library(digidoc_csharp TYPE SHARED LANGUAGE csharp SOURCES ../libdigidocpp.i)
-        target_link_libraries(digidoc_csharp digidocpp digidocpp_util)
+        target_compile_definitions(digidoc_csharp PRIVATE TARGET_NAME="$<TARGET_NAME:digidoc_csharp>")
+        target_link_libraries(digidoc_csharp digidocpp digidocpp_util digidocpp_ver)
         install(TARGETS digidoc_csharp DESTINATION ${CMAKE_INSTALL_BINDIR})
         install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/csharp/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/digidocpp_csharp FILES_MATCHING PATTERN "*.cs")
         install(FILES $<TARGET_PDB_FILE:digidoc_csharp> DESTINATION ${CMAKE_INSTALL_BINDIR} OPTIONAL)

--- a/src/digidoc-tool.cpp
+++ b/src/digidoc-tool.cpp
@@ -440,7 +440,7 @@ ToolConfig::ToolConfig(int argc, char *argv[])
         else if(arg == "--sigpsssha512") siguri = URI_RSA_PSS_SHA512;
         else if(arg.find("--tsurl") == 0) tsurl = arg.substr(8);
         else if(arg.find("--tslurl=") == 0) tslurl = arg.substr(9);
-        else if(arg.find("--tslcert=") == 0) tslcerts = { X509Cert(arg.substr(10)) };
+        else if(arg.find("--tslcert=") == 0) tslcerts = vector<X509Cert>{ X509Cert(arg.substr(10)) };
         else if(arg == "--TSLAllowExpired") expired = true;
         else if(arg == "--dontsign") doSign = false;
         else if(arg == "--nocolor") RED = GREEN = YELLOW = RESET = {};

--- a/src/libdigidocpp.i.h
+++ b/src/libdigidocpp.i.h
@@ -71,7 +71,7 @@ public:
     void setTSLCert(const std::vector<unsigned char> &cert)
     {
         if(cert.empty()) tslCerts.emplace();
-        else tslCerts = { X509Cert(cert, X509Cert::Der) };
+        else tslCerts = std::vector<X509Cert>{ X509Cert(cert, X509Cert::Der) };
     }
     void addTSLCert(const std::vector<unsigned char> &cert)
     {
@@ -89,7 +89,7 @@ public:
     void setVerifyServiceCert(const std::vector<unsigned char> &cert)
     {
         if(cert.empty()) serviceCerts.emplace();
-        else serviceCerts = { X509Cert(cert, X509Cert::Der) };
+        else serviceCerts = std::vector<X509Cert>{ X509Cert(cert, X509Cert::Der) };
     }
     void addVerifyServiceCert(const std::vector<unsigned char> &cert)
     {

--- a/src/libdigidocpp.rc
+++ b/src/libdigidocpp.rc
@@ -21,12 +21,12 @@ BEGIN
 		BLOCK "040904B0"
 		BEGIN
 			VALUE "CompanyName", "RIA"
-			VALUE "FileDescription", "digidocpp"
+			VALUE "FileDescription", TARGET_NAME
 			VALUE "FileVersion", VER_STR(MAJOR_VER.MINOR_VER.RELEASE_VER.BUILD_VER)
-			VALUE "InternalName", "digidocpp"
+			VALUE "InternalName", TARGET_NAME
 			VALUE "LegalCopyright", "(C) 2009-2023 Estonian Information System Authority"
-			VALUE "OriginalFilename", "digidocpp.dll"
-			VALUE "ProductName", "digidocpp"
+			VALUE "OriginalFilename", TARGET_NAME ".dll"
+			VALUE "ProductName", TARGET_NAME
 			VALUE "ProductVersion", VER_STR(MAJOR_VER.MINOR_VER.RELEASE_VER.BUILD_VER)
 		END
 	END


### PR DESCRIPTION
- add version info to swig bindings
- include manifest 1.2 schema

IB-7392

Signed-off-by: Raul Metsma <raul@metsma.ee>