### PR TITLE
Fix EVP_MD_CTX type definition for LibreSSL

### DIFF
--- a/src/crypto/Digest.h
+++ b/src/crypto/Digest.h
@@ -56,7 +56,11 @@
 #define URI_ECDSA_SHA384 "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha384"
 #define URI_ECDSA_SHA512 "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha512"
 
+#ifdef LIBRESSL_VERSION_NUMBER
+using EVP_MD_CTX = struct env_md_ctx_st;
+#else
 using EVP_MD_CTX = struct evp_md_ctx_st;
+#endif
 
 namespace digidoc
 {


### PR DESCRIPTION
From <openssl/evp.h> aka. EVP_Digest(3), otherwise OpenBSD builds fail:

```
/usr/include/openssl/ossl_typ.h:103:30: error: type alias redefinition with different types ('struct env_md_ctx_st' vs 'struct evp_md_ctx_st')
typedef struct env_md_ctx_st EVP_MD_CTX;
                             ^
/usr/ports/pobj/libdigidocpp-3.16.0/libdigidocpp-3.16.0/src/crypto/Digest.h:59:7: note: previous definition is here
using EVP_MD_CTX = struct evp_md_ctx_st;
```

As metsma@ advised, don't include the OpenSSL header in this header to
so as not to introduce build time dependencies to third party usages.

Signed-off-by: Klemens Nanni <kn@openbsd.org>
