### PR TITLE
Support minizip-ng build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Install Deps
       run: |
         dnf install -y --setopt=install_weak_deps=False \
-          git gcc-c++ cmake rpm-build xml-security-c-devel zlib-devel vim-common doxygen boost-test swig python3-devel java-1.8.0-openjdk-devel xsd
+          git gcc-c++ cmake rpm-build xml-security-c-devel zlib-devel vim-common doxygen boost-test swig python3-devel java-1.8.0-openjdk-devel xsd minizip-devel
     - name: Install CMake
       if: matrix.container == 'fedora:39'
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ find_package(ZLIB REQUIRED)
 find_package(MiniZip 1 QUIET) # version range (0...<2.0.0) requires CMake>=3.19
 if(UNIX AND NOT APPLE)
     find_package(PkgConfig)
-    pkg_check_modules(MINIZIP minizip IMPORTED_TARGET minizip<2.0.0)
+    pkg_check_modules(MINIZIP minizip IMPORTED_TARGET)
 endif()
 find_package(SWIG)
 find_package(JNI)

--- a/src/util/ZipSerialize.cpp
+++ b/src/util/ZipSerialize.cpp
@@ -22,6 +22,7 @@
 #include "DateTime.h"
 #include "log.h"
 
+#include <zlib.h>
 #include <minizip/unzip.h>
 #include <minizip/zip.h>
 #ifdef _WIN32


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Please update Signed-off-by info and read the common contributing guidelines
before you continue https://github.com/open-eid/.github/blob/master/CONTRIBUTING.md!
-->

Fedora has switched to `minizip-ng` (with the compat mode) and these patches fixed the failed build of `libdigidocpp`.

You can see more here: https://src.fedoraproject.org/rpms/libdigidocpp/pull-request/4

Signed-off-by: Lukas Javorsky <ljavorsk@redhat.com>
