### PR TITLE
Fix C# memory leaks and handle X509Cert as native type where possible

### DIFF
--- a/examples/DigiDocCSharp/DigiDocCSharp.csproj
+++ b/examples/DigiDocCSharp/DigiDocCSharp.csproj
@@ -2,9 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <OutputType>Exe</OutputType>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <AssemblyVersion>0.4.0.0</AssemblyVersion>
-    <FileVersion>0.4.0.0</FileVersion>
+    <AssemblyVersion>0.5.0.0</AssemblyVersion>
+    <FileVersion>0.5.0.0</FileVersion>
     <Copyright>Copyright ©  2015</Copyright>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">

--- a/examples/DigiDocCSharp/Program.cs
+++ b/examples/DigiDocCSharp/Program.cs
@@ -154,8 +154,7 @@ namespace DigiDocCSharp
                     b.addDataFile(args[i], "application/octet-stream");
                 }
 
-                X509Certificate cert = new X509Certificate();
-                cert.Import(args[args.Length - 2]);
+                var cert = new X509Certificate(args[args.Length - 2]);
                 Signature c = b.prepareWebSignature(cert.Export(X509ContentType.Cert), "time-stamp");
                 Console.WriteLine("Signature method: " + c.signatureMethod());
                 Console.WriteLine("Digest to sign: " + BitConverter.ToString(c.dataToSign()).Replace("-", string.Empty));
@@ -207,7 +206,8 @@ namespace DigiDocCSharp
                     Console.WriteLine();
 
                     Console.WriteLine("Time: " + s.trustedSigningTime());
-                    Console.WriteLine("Cert: " + new X509Certificate2(s.signingCertificateDer()).Subject);
+                    Console.WriteLine("Cert: " + s.signingCertificate().Subject);
+                    Console.WriteLine("TimeStamp: " + s.TimeStampCertificate().Subject);
 
                     s.validate();
                     Console.WriteLine("Signature is valid");

--- a/examples/java/src/main/java/ee/ria/libdigidocpp/libdigidocpp.java
+++ b/examples/java/src/main/java/ee/ria/libdigidocpp/libdigidocpp.java
@@ -149,7 +149,8 @@ public class libdigidocpp {
                 System.out.println();
 
                 System.out.println("Time: " + signature.trustedSigningTime());
-                System.out.println("Cert: " + toX509(signature.signingCertificateDer()).getSubjectDN().toString());
+                System.out.println("Cert: " + signature.signingCertificate().getSubjectDN().toString());
+                System.out.println("TimeStamp Cert: " + signature.TimeStampCertificate().getSubjectDN().toString());
 
                 try
                 {
@@ -171,7 +172,7 @@ public class libdigidocpp {
     }
 
     static void version() {
-        System.out.println("DigiDocJAVA 0.3 libdigidocpp " + digidoc.version());
+        System.out.println("DigiDocJAVA 0.4 libdigidocpp " + digidoc.version());
     }
 
     static X509Certificate toX509(byte[] der) throws CertificateException {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -202,7 +202,7 @@ if(SWIG_FOUND)
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/digidoc.py DESTINATION ${Python3_SITELIB})
     endif()
 
-    set(CMAKE_SWIG_FLAGS -dllimport digidoc_csharp -namespace digidoc)
+    set(CMAKE_SWIG_FLAGS -namespace digidoc)
     set(CMAKE_SWIG_OUTDIR ${CMAKE_CURRENT_BINARY_DIR}/csharp)
     swig_add_library(digidoc_csharp LANGUAGE csharp SOURCES ../libdigidocpp.i)
     target_compile_definitions(digidoc_csharp PRIVATE TARGET_NAME="$<TARGET_NAME:digidoc_csharp>")


### PR DESCRIPTION
IB-8235

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Please update Signed-off-by info and read the common contributing guidelines
before you continue https://github.com/open-eid/.github/blob/master/CONTRIBUTING.md!
-->

Signed-off-by: Raul Metsma <raul@metsma.ee>
