### PR TITLE
Fix typedef redefinition for struct env_md_ctx_st to unbreak with LibreSSL

### DIFF
--- a/src/crypto/Digest.h
+++ b/src/crypto/Digest.h
@@ -56,7 +56,7 @@
 #define URI_ECDSA_SHA384 "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha384"
 #define URI_ECDSA_SHA512 "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha512"
 
-#ifdef LIBRESSL_VERSION_NUMBER
+#if defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x3080200fL
 using EVP_MD_CTX = struct env_md_ctx_st;
 #else
 using EVP_MD_CTX = struct evp_md_ctx_st;


### PR DESCRIPTION
The underlying struct was renamed, in LibreSSL 3.8.2: https://github.com/openbsd/src/commit/7d242c13afd19e56cc21befac2ce5cdc1ac4992b

Follow-up to #550.

Signed-off-by: Klemens Nanni <kn@openbsd.org>
