### PR TITLE
Misc Fedora-related improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ env:
   BUILD_NUMBER: ${{ github.run_number }}
   CMAKE_BUILD_PARALLEL_LEVEL: 4
   # Required dependencies (does not include packaging and optional dependencies)
-  FEDORA_DEPS: cmake gcc-c++ libtool-ltdl-devel libxml2-devel minizip-ng-devel zlib-devel xmlsec1-openssl-devel
+  FEDORA_DEPS: cmake gcc-c++ libtool-ltdl-devel libxml2-devel minizip-ng-compat-devel zlib-devel xmlsec1-openssl-devel
   UBUNTU_DEPS: cmake libxml2-dev libxmlsec1-dev zlib1g-dev
 jobs:
   macos:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,14 +81,7 @@ jobs:
       matrix:
         container: [40, 41, rawhide]
     steps:
-    - name: Install CMake
-      if: matrix.container != 'rawhide'
-      run: |
-        dnf install -y --setopt=install_weak_deps=False \
-          ${FEDORA_DEPS} doxygen boost-test swig python3-devel java-17-openjdk-devel rpm-build git
     - name: Install Deps
-      ## Fedora 42 (currently) rawhide doesn't have Java 17 JDK?
-      if: matrix.container == 'rawhide'
       run: |
         dnf install -y --setopt=install_weak_deps=False \
           ${FEDORA_DEPS} doxygen boost-test swig python3-devel java-21-openjdk-devel rpm-build git

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,18 +77,12 @@ jobs:
     container: fedora:${{ matrix.container }}
     strategy:
       matrix:
-        container: [39, 40, 41]
+        container: [40, 41]
     steps:
     - name: Install Deps
       run: |
         dnf install -y --setopt=install_weak_deps=False \
           git gcc-c++ cmake rpm-build libxml2-devel xmlsec1-openssl-devel libtool-ltdl-devel zlib-devel doxygen boost-test swig python3-devel java-17-openjdk-devel minizip-devel
-    - name: Install CMake
-      if: matrix.container == 39
-      run: |
-        dnf install -y --setopt=install_weak_deps=False wget
-        wget -q https://github.com/Kitware/CMake/releases/download/v3.28.1/cmake-3.28.1-linux-x86_64.sh
-        sh cmake-3.28.1-linux-x86_64.sh --skip-license --prefix=/usr/local
     - name: Checkout
       uses: actions/checkout@v4
     - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,12 +79,19 @@ jobs:
     container: fedora:${{ matrix.container }}
     strategy:
       matrix:
-        container: [40, 41]
+        container: [40, 41, rawhide]
     steps:
-    - name: Install Deps
+    - name: Install CMake
+      if: matrix.container != 'rawhide'
       run: |
         dnf install -y --setopt=install_weak_deps=False \
           ${FEDORA_DEPS} doxygen boost-test swig python3-devel java-17-openjdk-devel rpm-build git
+    - name: Install Deps
+      ## Fedora 42 (currently) rawhide doesn't have Java 17 JDK?
+      if: matrix.container == 'rawhide'
+      run: |
+        dnf install -y --setopt=install_weak_deps=False \
+          ${FEDORA_DEPS} doxygen boost-test swig python3-devel java-21-openjdk-devel rpm-build git
     - name: Checkout
       uses: actions/checkout@v4
     - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ permissions:
 env:
   BUILD_NUMBER: ${{ github.run_number }}
   CMAKE_BUILD_PARALLEL_LEVEL: 4
+  # Required dependencies (does not include packaging and optional dependencies)
+  FEDORA_DEPS: cmake gcc-c++ libtool-ltdl-devel libxml2-devel minizip-ng-devel zlib-devel xmlsec1-openssl-devel
   UBUNTU_DEPS: cmake libxml2-dev libxmlsec1-dev zlib1g-dev
 jobs:
   macos:
@@ -82,7 +84,7 @@ jobs:
     - name: Install Deps
       run: |
         dnf install -y --setopt=install_weak_deps=False \
-          git gcc-c++ cmake rpm-build libxml2-devel xmlsec1-openssl-devel libtool-ltdl-devel zlib-devel doxygen boost-test swig python3-devel java-17-openjdk-devel minizip-devel
+          ${FEDORA_DEPS} doxygen boost-test swig python3-devel java-17-openjdk-devel rpm-build git
     - name: Checkout
       uses: actions/checkout@v4
     - name: Build

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
         # Ubuntu
         sudo apt install cmake libxml2-dev libxmlsec1-dev zlib1g-dev
         # Fedora
-        sudo dnf install cmake gcc-c++ libtool-ltdl-devel libxml2-devel minizip-ng-devel openssl-devel zlib-devel xmlsec1-openssl-devel
+        sudo dnf install cmake gcc-c++ libtool-ltdl-devel libxml2-devel minizip-ng-compat-devel openssl-devel zlib-devel xmlsec1-openssl-devel
 
 	* doxygen - Optional, for API documentation
 	* libboost-test-dev - Optional, for unittests

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
         # Ubuntu
         sudo apt install cmake libxml2-dev libxmlsec1-dev zlib1g-dev
         # Fedora
-        sudo dnf install cmake gcc-c++ openssl-devel libxml2-devel xmlsec1-openssl-devel libtool-ltdl-devel zlib-devel
+        sudo dnf install cmake gcc-c++ libtool-ltdl-devel libxml2-devel minizip-ng-devel openssl-devel zlib-devel xmlsec1-openssl-devel
 
 	* doxygen - Optional, for API documentation
 	* libboost-test-dev - Optional, for unittests


### PR DESCRIPTION
Some Fedora-related housekeeping due to upcoming Fedora 41 release:
Firstly, include `cmake` submodule using full repository url, which allows running Github actions without hardcoded relative repository locations.
And second and somewhat more controversial change would be the inclusion of `rawhide` in the Fedora build matrix. If there are objections, this could be dropped.