### PR TITLE
Fix crash when OCSP_RESPONSE does not contain OCSP_BASIC_RESPONSE

### DIFF
--- a/src/crypto/OCSP.cpp
+++ b/src/crypto/OCSP.cpp
@@ -132,7 +132,7 @@ OCSP::OCSP(const unsigned char *data, size_t size)
         return;
     resp.reset(d2i_OCSP_RESPONSE(nullptr, &data, long(size)), OCSP_RESPONSE_free);
     if(resp)
-       basic.reset(OCSP_response_get1_basic(resp.get()), OCSP_BASICRESP_free);
+        basic.reset(OCSP_response_get1_basic(resp.get()), OCSP_BASICRESP_free);
 }
 
 bool OCSP::compareResponderCert(const X509Cert &cert) const
@@ -183,7 +183,7 @@ OCSP::operator vector<unsigned char>() const
  */
 void OCSP::verifyResponse(const X509Cert &cert) const
 {
-    if(!resp)
+    if(!basic)
         THROW("Failed to verify OCSP response.");
 
     tm tm = producedAt();


### PR DESCRIPTION
IB-8299

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Please update Signed-off-by info and read the common contributing guidelines
before you continue https://github.com/open-eid/.github/blob/master/CONTRIBUTING.md!
-->

Signed-off-by: Raul Metsma <raul@metsma.ee>
