### PR TITLE
Add ConfV6 class with validateSigningCert method

### DIFF
--- a/src/Conf.cpp
+++ b/src/Conf.cpp
@@ -352,3 +352,30 @@ vector<X509Cert> ConfV5::TSCerts() const
 {
     return {};
 }
+
+/**
+ * @class digidoc::ConfV6
+ * @brief Verison 6 of configuration class to add additonial parameters.
+ *
+ * Conf contains virtual members and is not leaf class we need create
+ * subclasses to keep binary compatibility
+ * https://techbase.kde.org/Policies/Binary_Compatibility_Issues_With_C++#Adding_new_virtual_functions_to_leaf_classes
+ * @see digidoc::ConfV5
+ * @see @ref parameters
+ */
+/**
+ * Version 6 config with new parameters
+ */
+ConfV6::ConfV6() = default;
+
+ConfV6::~ConfV6() = default;
+
+/**
+ * @copydoc digidoc::Conf::instance()
+ */
+ConfV6* ConfV6::instance() { return dynamic_cast<ConfV6*>(Conf::instance()); }
+
+/**
+ * Gets signing certificate ignoring parameter
+ */
+bool ConfV6::validateSigningCert() const { return true; }

--- a/src/Conf.h
+++ b/src/Conf.h
@@ -126,6 +126,20 @@ private:
     DISABLE_COPY(ConfV5);
 };
 
-using ConfCurrent = ConfV5;
+class DIGIDOCPP_EXPORT ConfV6: public ConfV5
+{
+public:
+    ConfV6();
+    ~ConfV6() override;
+    static ConfV6* instance();
+
+    virtual bool validateSigningCert() const;
+
+private:
+    DISABLE_COPY(ConfV6);
+};
+
+using ConfCurrent = ConfV6;
 #define CONF(method) (ConfCurrent::instance() ? ConfCurrent::instance()->method() : ConfCurrent().method())
 }
+

--- a/src/SignatureCAdES_B.cpp
+++ b/src/SignatureCAdES_B.cpp
@@ -20,6 +20,8 @@
 #include <SignatureCAdES_B.h>
 #include <SignatureCAdES_p.h>
 
+#include "Conf.h"
+
 #include <crypto/Digest.h>
 #include <crypto/OpenSSLHelpers.h>
 #include <crypto/Signer.h>
@@ -178,8 +180,11 @@ void SignatureCAdES_B::validate(const string &policy) const
         string time = trustedSigningTime();
         if(time.empty())
             THROW("SigningTime missing");
-        if(!X509CertStore::instance()->verify(signingCertificate(), policy == POLv1))
-            THROW("Unable to verify signing certificate");
+        if(CONF(validateSigningCert))
+        {
+            if(!X509CertStore::instance()->verify(signingCertificate(), policy == POLv1))
+                THROW("Unable to verify signing certificate");
+        }
     } catch(const Exception &e) {
         exception.addCause(e);
     }

--- a/src/SignatureXAdES_B.cpp
+++ b/src/SignatureXAdES_B.cpp
@@ -546,8 +546,11 @@ void SignatureXAdES_B::validate(const string &policy) const
         try { checkKeyInfo(); }
         catch(const Exception& e) { exception.addCause(e); }
 
-        try { checkSigningCertificate(policy == POLv1); }
-        catch(const Exception& e) { exception.addCause(e); }
+        if(CONF(validateSigningCert))
+        {
+            try { checkSigningCertificate(policy == POLv1); }
+            catch(const Exception& e) { exception.addCause(e); }
+        }
     } catch(const Exception &e) {
         exception.addCause(e);
     } catch(...) {

--- a/src/SignatureXAdES_T.cpp
+++ b/src/SignatureXAdES_T.cpp
@@ -20,6 +20,7 @@
 #include "SignatureXAdES_T.h"
 
 #include "ASiC_E.h"
+#include "Conf.h"
 #include "crypto/Digest.h"
 #include "crypto/OCSP.h"
 #include "crypto/Signer.h"
@@ -114,8 +115,11 @@ void SignatureXAdES_T::validate(const std::string &policy) const
             signatures->c14n(digest, canonicalizationMethod, signatureValue());
         });
 
-        if(!X509CertStore::instance()->verify(signingCertificate(), policy == POLv1, tsa.time()))
-            THROW("Signing certificate was not valid on signing time");
+        if(CONF(validateSigningCert))
+        {
+            if(!X509CertStore::instance()->verify(signingCertificate(), policy == POLv1, tsa.time()))
+                THROW("Signing certificate was not valid on signing time");
+        }
 
         auto completeCertRefs = usp/"CompleteCertificateRefs";
         if(completeCertRefs + 1)


### PR DESCRIPTION
validateSigningCert method allows to bypass certificate trust check during signature verification.

Fixes #678

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Please update Signed-off-by info and read the common contributing guidelines
before you continue https://github.com/open-eid/.github/blob/master/CONTRIBUTING.md!
-->

Signed-off-by: Florian Dargère <florian.dargere@idopte.com>
