### PR TITLE
CMake: define digidocpp_EXPORTS for static builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -255,8 +255,11 @@ if(SWIG_FOUND)
     endif()
 endif()
 
-if(NOT ${BUILD_SHARED_LIBS})
+if(NOT BUILD_SHARED_LIBS)
     set(STATIC_TARGETS minizip digidocpp_tsl digidocpp_util)
+    target_compile_definitions(digidocpp PUBLIC digidocpp_STATIC)
+    target_compile_definitions(digidocpp_tsl PUBLIC digidocpp_STATIC)
+    target_compile_definitions(digidocpp_util PUBLIC digidocpp_STATIC)
 endif()
 
 install(TARGETS digidocpp ${STATIC_TARGETS}
@@ -390,9 +393,6 @@ if( FRAMEWORK )
         COMMAND zip -r ${PROJECT_BINARY_DIR}/libdigidocpp-dbg_${VERSION}$ENV{VER_SUFFIX}.zip libdigidocpp.dSYM
     )
 else()
-    if(NOT ${BUILD_SHARED_LIBS})
-        install( TARGETS minizip digidocpp_tsl digidocpp_util DESTINATION ${CMAKE_INSTALL_LIBDIR} )
-    endif()
     if( BUILD_TOOLS )
         install( TARGETS digidoc-tool DESTINATION ${CMAKE_INSTALL_BINDIR} )
         install( FILES ${CMAKE_CURRENT_BINARY_DIR}/digidoc-tool.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,9 +81,10 @@ add_library(digidocpp_tsl STATIC
 )
 
 set_target_properties(digidocpp_util digidocpp_tsl PROPERTIES
-    COMPILE_DEFINITIONS digidocpp_EXPORTS
     POSITION_INDEPENDENT_CODE YES
 )
+target_compile_definitions(digidocpp_tsl PUBLIC $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,digidocpp_EXPORTS,digidocpp_STATIC>)
+target_compile_definitions(digidocpp_util PUBLIC $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,digidocpp_EXPORTS,digidocpp_STATIC>)
 
 target_include_directories(digidocpp_tsl PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
@@ -258,8 +259,6 @@ endif()
 if(NOT BUILD_SHARED_LIBS)
     set(STATIC_TARGETS minizip digidocpp_tsl digidocpp_util)
     target_compile_definitions(digidocpp PUBLIC digidocpp_STATIC)
-    target_compile_definitions(digidocpp_tsl PUBLIC digidocpp_STATIC)
-    target_compile_definitions(digidocpp_util PUBLIC digidocpp_STATIC)
 endif()
 
 install(TARGETS digidocpp ${STATIC_TARGETS}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -261,8 +261,11 @@ if(SWIG_FOUND)
     endif()
 endif()
 
-if(NOT ${BUILD_SHARED_LIBS})
+if(NOT BUILD_SHARED_LIBS)
     set(STATIC_TARGETS minizip digidocpp_tsl digidocpp_util)
+    target_compile_definitions(digidocpp PUBLIC digidocpp_STATIC)
+    target_compile_definitions(digidocpp_tsl PUBLIC digidocpp_STATIC)
+    target_compile_definitions(digidocpp_util PUBLIC digidocpp_STATIC)
 endif()
 
 install(TARGETS digidocpp ${STATIC_TARGETS}
@@ -398,9 +401,6 @@ if( FRAMEWORK )
         COMMAND zip -r ${PROJECT_BINARY_DIR}/libdigidocpp-dbg_${VERSION}$ENV{VER_SUFFIX}.zip libdigidocpp.dSYM
     )
 else()
-    if(NOT ${BUILD_SHARED_LIBS})
-        install( TARGETS minizip digidocpp_tsl digidocpp_util DESTINATION ${CMAKE_INSTALL_LIBDIR} )
-    endif()
     if( BUILD_TOOLS )
         install( TARGETS digidoc-tool DESTINATION ${CMAKE_INSTALL_BINDIR} )
         install( FILES ${CMAKE_CURRENT_BINARY_DIR}/digidoc-tool.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,9 +85,10 @@ add_library(digidocpp_tsl STATIC
 )
 
 set_target_properties(digidocpp_util digidocpp_tsl PROPERTIES
-    COMPILE_DEFINITIONS digidocpp_EXPORTS
     POSITION_INDEPENDENT_CODE YES
 )
+target_compile_definitions(digidocpp_tsl PUBLIC $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,digidocpp_EXPORTS,digidocpp_STATIC>)
+target_compile_definitions(digidocpp_util PUBLIC $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,digidocpp_EXPORTS,digidocpp_STATIC>)
 
 target_include_directories(digidocpp_tsl PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
@@ -264,8 +265,6 @@ endif()
 if(NOT BUILD_SHARED_LIBS)
     set(STATIC_TARGETS minizip digidocpp_tsl digidocpp_util)
     target_compile_definitions(digidocpp PUBLIC digidocpp_STATIC)
-    target_compile_definitions(digidocpp_tsl PUBLIC digidocpp_STATIC)
-    target_compile_definitions(digidocpp_util PUBLIC digidocpp_STATIC)
 endif()
 
 install(TARGETS digidocpp ${STATIC_TARGETS}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,8 +87,8 @@ add_library(digidocpp_tsl STATIC
 set_target_properties(digidocpp_util digidocpp_tsl PROPERTIES
     POSITION_INDEPENDENT_CODE YES
 )
-target_compile_definitions(digidocpp_tsl PUBLIC $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,digidocpp_EXPORTS,digidocpp_STATIC>)
-target_compile_definitions(digidocpp_util PUBLIC $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,digidocpp_EXPORTS,digidocpp_STATIC>)
+target_compile_definitions(digidocpp_tsl PRIVATE $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,digidocpp_EXPORTS,digidocpp_STATIC>)
+target_compile_definitions(digidocpp_util PRIVATE $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,digidocpp_EXPORTS,digidocpp_STATIC>)
 
 target_include_directories(digidocpp_tsl PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 

--- a/src/Exports.h
+++ b/src/Exports.h
@@ -21,7 +21,9 @@
 
 #ifdef WIN32
   #include <winapifamily.h>
-  #ifdef digidocpp_EXPORTS
+  #ifdef digidocpp_STATIC
+    #define DIGIDOCPP_EXPORT
+  #elifdef digidocpp_EXPORTS
     #define DIGIDOCPP_EXPORT __declspec(dllexport)
   #else
     #define DIGIDOCPP_EXPORT __declspec(dllimport)


### PR DESCRIPTION
## Summary

- When `BUILD_SHARED_LIBS=OFF` on Windows, CMake does not define `digidocpp_EXPORTS` on the `digidocpp` target (only done automatically for shared libraries)
- This causes `DIGIDOCPP_EXPORT` in `Exports.h` to resolve to `__declspec(dllimport)` instead of `__declspec(dllexport)`
- Applies the same pattern already used for `digidocpp_util` and `digidocpp_tsl` (line 83-84): sets `COMPILE_DEFINITIONS digidocpp_EXPORTS` on the target for static builds

## Test plan

- Build with `BUILD_SHARED_LIBS=OFF` on Windows — `DIGIDOCPP_EXPORT` should resolve to `__declspec(dllexport)`
- Build with `BUILD_SHARED_LIBS=ON` on Windows — no change, CMake defines `digidocpp_EXPORTS` automatically